### PR TITLE
fix(chat): raise intent token budget and surface gateway 422 reasoning rejections

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,6 +61,8 @@ By default, chat requests use the queued LLM gateway and its `gemma-4-26b-a4b` m
 
 `thinkingLevel` follows the canonical [ReasoningEffortLevel](../src/main/java/com/composerai/api/domain/model/ReasoningEffortLevel.java) contract. Composer forwards every valid effort unchanged to any configured OpenAI-compatible generation endpoint without inspecting the model alias or provider type. An explicit `thinkingLevel` wins; when the level is absent, `thinkingEnabled: false` maps to the intentional `none` effort. Omitting both fields preserves any configured default, including configured `none`, and otherwise uses the enum's canonical reasoning-on default. Unsupported combinations fail explicitly at the upstream endpoint.
 
+The UI's "None" thinking option is honored only for GENERAL-class gateway keys; other key classes are clamped to reasoning-ON by the gateway.
+
 ### OpenRouter
 
 To use [OpenRouter](https://openrouter.ai), set `OPENAI_BASE_URL=https://openrouter.ai/api/v1` and your OpenRouter API key.

--- a/src/main/java/com/composerai/api/adapters/in/web/ChatController.java
+++ b/src/main/java/com/composerai/api/adapters/in/web/ChatController.java
@@ -1,5 +1,6 @@
 package com.composerai.api.adapters.in.web;
 
+import com.composerai.api.adapters.out.openai.ReasoningIntentRejection;
 import com.composerai.api.application.dto.ChatRequest;
 import com.composerai.api.application.usecase.chat.ChatPromptComposer;
 import com.composerai.api.application.usecase.chat.ChatStreamCallbacks;
@@ -202,7 +203,7 @@ public class ChatController {
     }
 
     private void handleError(StreamContext context, Throwable error) {
-        String safeMessage = errorMessages.getStream().getError();
+        String safeMessage = streamErrorMessage(error);
         try {
             context.emitter()
                     .send(SseEmitter.event()
@@ -215,6 +216,14 @@ public class ChatController {
         context.completed().set(true);
         context.heartbeatTask().cancel(false);
         context.emitter().complete();
+    }
+
+    private String streamErrorMessage(Throwable error) {
+        // Deterministic and non-retryable: no candidate provider can preserve the requested effort.
+        if (ReasoningIntentRejection.isUnpreservable(error)) {
+            return errorMessages.getStream().getReasoningEffortUnsupported();
+        }
+        return errorMessages.getStream().getError();
     }
 
     private void handleStartupError(SseEmitter emitter, Exception e) {

--- a/src/main/java/com/composerai/api/adapters/out/openai/OpenAiChatClient.java
+++ b/src/main/java/com/composerai/api/adapters/out/openai/OpenAiChatClient.java
@@ -107,7 +107,7 @@ public class OpenAiChatClient {
      *
      * Configuration source of truth: OpenAiProperties.java
      * Default category: {@link OpenAiProperties.Intent#getDefaultCategory()} - "question"
-     * Max tokens: {@link OpenAiProperties.Intent#getMaxOutputTokens()} - 10
+     * Max tokens: {@link OpenAiProperties.Intent#getMaxOutputTokens()} - 512
      */
     public String analyzeIntent(String userMessage) {
         String defaultCategory = openAiProperties.getIntent().getDefaultCategory();

--- a/src/main/java/com/composerai/api/adapters/out/openai/ReasoningIntentRejection.java
+++ b/src/main/java/com/composerai/api/adapters/out/openai/ReasoningIntentRejection.java
@@ -1,0 +1,36 @@
+package com.composerai.api.adapters.out.openai;
+
+import com.openai.errors.OpenAIServiceException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Detects the shared gateway's deterministic HTTP 422 {@code unpreservable_reasoning_intent}
+ * rejection: the requested reasoning effort cannot be preserved by any candidate provider,
+ * so retrying unchanged can never succeed.
+ */
+public final class ReasoningIntentRejection {
+
+    private static final String UNPRESERVABLE_REASONING_INTENT_CODE = "unpreservable_reasoning_intent";
+
+    private ReasoningIntentRejection() {}
+
+    public static boolean isUnpreservable(Throwable error) {
+        boolean sawUnprocessableEntity = false;
+        boolean sawGatewayCode = false;
+        for (Throwable current = error; current != null; current = current.getCause()) {
+            if (current instanceof OpenAIServiceException serviceException
+                    && serviceException.statusCode() == HttpStatus.UNPROCESSABLE_ENTITY.value()) {
+                sawUnprocessableEntity = true;
+                sawGatewayCode |= serviceException
+                        .code()
+                        .map(UNPRESERVABLE_REASONING_INTENT_CODE::equals)
+                        .orElse(false);
+            }
+            String message = current.getMessage();
+            if (message != null && message.contains(UNPRESERVABLE_REASONING_INTENT_CODE)) {
+                sawGatewayCode = true;
+            }
+        }
+        return sawUnprocessableEntity && sawGatewayCode;
+    }
+}

--- a/src/main/java/com/composerai/api/config/ErrorMessagesProperties.java
+++ b/src/main/java/com/composerai/api/config/ErrorMessagesProperties.java
@@ -40,5 +40,7 @@ public class ErrorMessagesProperties {
     public static class Stream {
         private String error = "Stream error - connection may have been lost";
         private String timeout = "Request timed out - please try again";
+        private String reasoningEffortUnsupported =
+                "The selected reasoning effort is not supported for this model. Choose a lower thinking level and try again.";
     }
 }

--- a/src/main/java/com/composerai/api/config/OpenAiProperties.java
+++ b/src/main/java/com/composerai/api/config/OpenAiProperties.java
@@ -135,13 +135,16 @@ public class OpenAiProperties {
 
     /**
      * Intent analysis configuration.
-     * Defaults: "question" category, 10 max tokens, standard categories
+     * Defaults: "question" category, 512 max tokens, standard categories.
+     * Token budget must cover reasoning plus the category token: reasoning draws from
+     * the same max_output_tokens budget on some upstreams, so a tiny cap can starve
+     * the visible answer.
      */
     @Getter
     @Setter
     public static class Intent {
         private String defaultCategory = "question";
-        private long maxOutputTokens = 10L;
+        private long maxOutputTokens = 512L;
         private String categories = "search, compose, summarize, analyze, question, or other";
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -61,9 +61,12 @@ openai.provider.allow-fallbacks=${LLM_PROVIDER_ALLOW_FALLBACKS:true}
 # Debug Configuration
 openai.local-debug-enabled=${OPENAI_LOCAL_DEBUG:false}
 
-# Intent Analysis (defaults: question / 10 tokens / standard categories)
+# Intent Analysis (defaults: question / 512 tokens / standard categories)
+# Token budget must cover reasoning plus the category token: on upstreams where
+# reasoning draws from the same max_output_tokens budget, a tiny cap lets the model
+# spend it all thinking and return empty visible text (degrading to the default category).
 openai.intent.default-category=${OPENAI_INTENT_DEFAULT:question}
-openai.intent.max-output-tokens=${OPENAI_INTENT_MAX_TOKENS:10}
+openai.intent.max-output-tokens=${OPENAI_INTENT_MAX_TOKENS:512}
 openai.intent.categories=${OPENAI_INTENT_CATEGORIES:search, compose, summarize, analyze, question, other}
 
 # Request Defaults (defaults: 5 results / 4000 chars / thinking unspecified)
@@ -84,6 +87,7 @@ openai.defaults.thinking-enabled=${OPENAI_THINKING_ENABLED:}
 # messages.chat.processing-error=${MESSAGES_CHAT_ERROR}
 # messages.stream.error=${MESSAGES_STREAM_ERROR}
 # messages.stream.timeout=${MESSAGES_STREAM_TIMEOUT}
+# messages.stream.reasoning-effort-unsupported=${MESSAGES_STREAM_REASONING_EFFORT_UNSUPPORTED}
 
 # Qdrant Configuration
 qdrant.enabled=${QDRANT_ENABLED:false}

--- a/src/test/java/com/composerai/api/ComposerAiApiApplicationTests.java
+++ b/src/test/java/com/composerai/api/ComposerAiApiApplicationTests.java
@@ -22,7 +22,7 @@ import org.springframework.test.context.TestPropertySource;
             "openai.defaults.thinking-enabled=",
             "openai.defaults.max-message-length=4000",
             "openai.defaults.max-search-results=5",
-            "openai.intent.max-output-tokens=10",
+            "openai.intent.max-output-tokens=512",
             "openai.intent.default-category=question",
             "openai.stream.heartbeat-interval-seconds=10",
             "openai.stream.timeout-seconds=120",

--- a/src/test/java/com/composerai/api/adapters/in/web/ChatControllerIT.java
+++ b/src/test/java/com/composerai/api/adapters/in/web/ChatControllerIT.java
@@ -222,6 +222,62 @@ class ChatControllerIT {
                         any(ChatStreamCallbacks.class));
     }
 
+    @Test
+    void streamEndpoint_ShouldSurfaceUnpreservableReasoningIntent() throws Exception {
+        var streamConfig = new com.composerai.api.config.OpenAiProperties.Stream();
+        streamConfig.setTimeoutSeconds(120);
+        Mockito.when(openAiProperties.getStream()).thenReturn(streamConfig);
+        Mockito.when(errorMessagesProperties.getStream())
+                .thenReturn(new com.composerai.api.config.ErrorMessagesProperties.Stream());
+
+        java.util.concurrent.ScheduledFuture<?> mockFuture = Mockito.mock(java.util.concurrent.ScheduledFuture.class);
+        Mockito.<java.util.concurrent.ScheduledFuture<?>>when(sseHeartbeatExecutor.scheduleAtFixedRate(
+                        any(Runnable.class),
+                        org.mockito.ArgumentMatchers.anyLong(),
+                        org.mockito.ArgumentMatchers.anyLong(),
+                        any(java.util.concurrent.TimeUnit.class)))
+                .thenReturn(mockFuture);
+
+        doAnswer(invocation -> {
+                    Runnable runnable = invocation.getArgument(0);
+                    runnable.run();
+                    return null;
+                })
+                .when(chatStreamExecutor)
+                .execute(any(Runnable.class));
+
+        com.openai.errors.UnprocessableEntityException upstream =
+                com.openai.errors.UnprocessableEntityException.builder()
+                        .headers(com.openai.core.http.Headers.builder().build())
+                        .error(com.openai.models.ErrorObject.builder()
+                                .message("no candidate provider can preserve the requested reasoning effort")
+                                .code("unpreservable_reasoning_intent")
+                                .param(java.util.Optional.empty())
+                                .type("invalid_request_error")
+                                .build())
+                        .build();
+        doAnswer(invocation -> {
+                    ChatStreamCallbacks callbacks = invocation.getArgument(3);
+                    callbacks.onError().accept(new RuntimeException(upstream.getMessage(), upstream));
+                    return null;
+                })
+                .when(streamChatUseCase)
+                .execute(
+                        any(ChatRequest.class),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        any(ChatStreamCallbacks.class));
+
+        ChatRequest request = new ChatRequest("Summarize", null, 5);
+
+        mockMvc.perform(post(CHAT_ENDPOINT + "/stream")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("event:error")))
+                .andExpect(content().string(containsString("reasoning effort is not supported")));
+    }
+
     @TestConfiguration
     static class TestConfig {
         @Bean

--- a/src/test/java/com/composerai/api/adapters/out/openai/ReasoningIntentRejectionTest.java
+++ b/src/test/java/com/composerai/api/adapters/out/openai/ReasoningIntentRejectionTest.java
@@ -1,0 +1,67 @@
+package com.composerai.api.adapters.out.openai;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.openai.core.http.Headers;
+import com.openai.errors.UnprocessableEntityException;
+import com.openai.models.ErrorObject;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ReasoningIntentRejectionTest {
+
+    private static final String GATEWAY_CODE = "unpreservable_reasoning_intent";
+
+    @Test
+    void matchesWrappedGatewayRejection() {
+        UnprocessableEntityException upstream = UnprocessableEntityException.builder()
+                .headers(Headers.builder().build())
+                .error(ErrorObject.builder()
+                        .message("no candidate provider can preserve the requested reasoning effort")
+                        .code(GATEWAY_CODE)
+                        .param(Optional.empty())
+                        .type("invalid_request_error")
+                        .build())
+                .build();
+        RuntimeException wrapped = new RuntimeException(upstream.getMessage(), upstream);
+
+        assertTrue(ReasoningIntentRejection.isUnpreservable(wrapped));
+    }
+
+    @Test
+    void matchesGatewayCodeCarriedOnlyInMessage() {
+        UnprocessableEntityException upstream = UnprocessableEntityException.builder()
+                .headers(Headers.builder().build())
+                .build();
+        RuntimeException wrapped =
+                new RuntimeException("422: {\"detail\":{\"code\":\"" + GATEWAY_CODE + "\"}}", upstream);
+
+        assertTrue(ReasoningIntentRejection.isUnpreservable(wrapped));
+    }
+
+    @Test
+    void ignoresUnprocessableEntityWithoutGatewayCode() {
+        UnprocessableEntityException upstream = UnprocessableEntityException.builder()
+                .headers(Headers.builder().build())
+                .error(ErrorObject.builder()
+                        .message("validation failed")
+                        .code(Optional.empty())
+                        .param(Optional.empty())
+                        .type("invalid_request_error")
+                        .build())
+                .build();
+
+        assertFalse(ReasoningIntentRejection.isUnpreservable(new RuntimeException(upstream)));
+    }
+
+    @Test
+    void ignoresGatewayCodeWithoutUnprocessableEntity() {
+        assertFalse(ReasoningIntentRejection.isUnpreservable(new RuntimeException("boom: " + GATEWAY_CODE)));
+    }
+
+    @Test
+    void ignoresGenericFailures() {
+        assertFalse(ReasoningIntentRejection.isUnpreservable(new RuntimeException("connection reset")));
+    }
+}

--- a/src/test/java/com/composerai/api/adapters/out/openai/UniversalReasoningContractTest.java
+++ b/src/test/java/com/composerai/api/adapters/out/openai/UniversalReasoningContractTest.java
@@ -118,6 +118,9 @@ class UniversalReasoningContractTest {
         assertEquals(
                 "xhigh",
                 request.reasoning().orElseThrow().effort().orElseThrow().asString());
+        assertEquals(
+                properties.getIntent().getMaxOutputTokens(),
+                request.maxOutputTokens().orElseThrow());
         assertEquals(List.of(INTERACTIVE_GATEWAY_TIER), request._headers().values(GATEWAY_TIER_HEADER));
     }
 


### PR DESCRIPTION
Fast-forwards main with dev@072a6ab:

- intent max-output-tokens default 10 -> 512 so the budget covers reasoning plus the category token
- ReasoningIntentRejection detects the gateway's deterministic 422 unpreservable_reasoning_intent through the cause chain; ChatController emits a dedicated reasoning-effort-unsupported stream message
- docs note the "None" thinking option is honored only for GENERAL-class gateway keys

Dogfooded end-to-end against the llm-gateway (gemma-4-26b-a4b): low/medium/high reasoning streams verified, xhigh correctly surfaces the dedicated 422 message, intent classification returns proper categories under the new budget.